### PR TITLE
Added ability to get stream from Observable List

### DIFF
--- a/src/main/java/lwjgui/collections/ObservableList.java
+++ b/src/main/java/lwjgui/collections/ObservableList.java
@@ -2,6 +2,7 @@ package lwjgui.collections;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import lwjgui.event.ElementCallback;
 
@@ -102,5 +103,13 @@ public class ObservableList<E> {
 
 	public boolean contains(E element) {
 		return internal.contains(element);
+	}
+
+	public Stream<E> stream() {
+		return this.internal.stream();
+	}
+
+	public Stream<E> parallelStream() {
+		return this.internal.parallelStream();
 	}
 }


### PR DESCRIPTION
Stream are read-only so it's safe from the list point of view. This allows for easier Filter-Map-Reduce-like operations:

`for(int i = 0; i < this.getChildren().size(); i++) {
            this.getChildren().get(i).setMaxWidth(Double.MAX_VALUE);
        }`

becomes

`this.getChildren().stream().forEach(e -> e.setMaxWidth(W));`

This is especially useful since ObservableList is not iterable