### PR TITLE
update lwjgl version to 3.3 to be usable with LibGDX 1.12.1 without dependency conflict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ plugins {
 }
 
 sourceCompatibility = "8"
-project.ext.lwjglVersion = "3.2.3"
-project.ext.jomlVersion = "1.9.20"
+project.ext.lwjglVersion = "3.3.3"
+project.ext.jomlVersion = "1.10.6"
 
 group = "org.lwjgui"
 version = "1.0.0-SNAPSHOT"
@@ -102,6 +102,9 @@ dependencies {
 	}
 
 	api "org.joml:joml:${jomlVersion}"
+}
+tasks.withType(ProcessResources.class).configureEach {
+	duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
 publishing {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/lwjgui/scene/Context.java
+++ b/src/main/java/lwjgui/scene/Context.java
@@ -458,7 +458,7 @@ public class Context {
 		int fontCallback;
 		try {
 			// Create normal font
-			fontCallback = NanoVG.nvgCreateFontMem(nvgContext, fontName, fontData, 0);
+			fontCallback = NanoVG.nvgCreateFontMem(nvgContext, fontName, fontData, false);
 			fontBuffers.add(fontData);
 
 			// Fallback emoji fonts
@@ -475,7 +475,7 @@ public class Context {
 	}
 
 	private void addFallback(int fontCallback, String name, ByteBuffer fontData) {
-		NanoVG.nvgAddFallbackFontId(nvgContext, fontCallback, NanoVG.nvgCreateFontMem(nvgContext, name, fontData, 0));
+		NanoVG.nvgAddFallbackFontId(nvgContext, fontCallback, NanoVG.nvgCreateFontMem(nvgContext, name, fontData, false));
 	}
 	
 	private static InputStream inputStream(String path) throws IOException {


### PR DESCRIPTION
libgdx uses 3.3.3, lwjgl will complain or crash if there's version conflicts so this is necessary to make it work.

there's only one breaking change in the newer nanoVG version which I resolved, tests run fine as well